### PR TITLE
Fix CSS to ensure the entire wordcloud is visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta name="viewport" content="width=320, initial-scale=1">
     <title>hpc.github.io</title>
+    <style>
+    html, body {
+        height: 100%;
+        overflow: hidden;
+    }
+    </style>
   </head>
   <body>
     <script src="js/d3.v3.min.js"></script>


### PR DESCRIPTION
I see the following when I go to hpc.github.io (Ubuntu 16.04, Google Chrome 56) ![image](https://cloud.githubusercontent.com/assets/116683/23106509/81a02680-f6bc-11e6-9f57-c469530ddc1f.png)

This PR sets the height of the `html` and `body` elements to be 100% so that the `svg` element will take up the full height of the page as seen below

![image](https://cloud.githubusercontent.com/assets/116683/23106517/bb1d8c5e-f6bc-11e6-87c1-4bab31861e4f.png)
